### PR TITLE
Import api entity instead of rewriting it in renderer

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,13 +1,12 @@
-import {contextBridge, ipcRenderer} from 'electron'
-// const os = require('os')
+import { contextBridge, ipcRenderer } from "electron";
 
-contextBridge.exposeInMainWorld(
-    'menu', {
-        send: (channel: string, data: any) => {
-            ipcRenderer.send(channel, data)
-        },
-        receive: (channel: string, func: Function) => {
-            ipcRenderer.on(channel, (_event, ...args) => func(...args))
-        },
-    }
-)
+export const electronApi = {
+  send: (channel: string, data: any) => {
+    ipcRenderer.send(channel, data);
+  },
+  receive: (channel: string, func: Function) => {
+    ipcRenderer.on(channel, (_event, ...args) => func(...args));
+  },
+};
+
+contextBridge.exposeInMainWorld("menu", electronApi);

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1,13 +1,7 @@
-/**
- * Should match main/preload.ts for typescript support in renderer
- */
-export default interface ElectronApi {
-	send: (channel: string, data: any) => void,
-	receive: (channel: string, func: Function) => void
-}
+import { electronApi } from "../../main/preload";
 
 declare global {
-	interface Window {
-		menu: ElectronApi,
-	}
+  interface Window {
+    menu: typeof electronApi;
+  }
 }


### PR DESCRIPTION
instead of declaring the electorn bridge object in the renderer, export it from electron and use it's type in the front.